### PR TITLE
Systemd user mode and restart

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,8 @@ var linuxSystemUnit = [
 	'UMask=0007',
 	'ExecStart=##NODE_PATH## ##NODE_ARGS## ##PROGRAM_PATH## ##PROGRAM_ARGS##',
 	'',
-	'[Install]'
+	'[Install]',
+	'WantedBy=##TARGET##'
 ];
 
 function getServiceWrap () {
@@ -248,6 +249,9 @@ function add (name, options, cb) {
 		var nodeArgsStr = nodeArgs.join(" ");
 		var programArgsStr = programArgs.join(" ");
 
+		var systemdTarget = "multi-user.target";
+		if (options && options.systemdTarget)
+			systemdTarget = options.systemdTarget;
 
 		var initPath = "/etc/init.d/" + name;
 		var systemdFolder = "/etc/systemd/system";
@@ -321,6 +325,7 @@ function add (name, options, cb) {
 					line = line.replace("##NODE_ARGS##", nodeArgsStr);
 					line = line.replace("##PROGRAM_PATH##", programPath);
 					line = line.replace("##PROGRAM_ARGS##", programArgsStr);
+					line = line.replace("##TARGET##", systemdTarget);
 					
 					systemUnit.push(line);
 				}

--- a/index.js
+++ b/index.js
@@ -250,18 +250,20 @@ function add (name, options, cb) {
 
 
 		var initPath = "/etc/init.d/" + name;
-		var systemPath = "/usr/lib/systemd/system/" + name + ".service";
+		var systemdFolder = "/etc/systemd/system";
 		
 		var systemdInUserMode = (options && options.userMode);
 		if (systemdInUserMode) {
-			systemPath = os.homedir() + "/.config/systemd/user/"+ name + ".service";
+			systemdFolder = os.homedir() + "/.config/systemd/user";
 		}
+
+		var systemPath = systemdFolder + "/" + name + ".service";
 
 		var ctlOptions = {
 			mode: 493 // rwxr-xr-x
 		};
 
-		fs.stat("/usr/lib/systemd/system1", function(error, stats) {
+		fs.stat(systemdFolder, function(error, stats) {
 			if (error) {
 				if (error.code == "ENOENT") {
 					var startStopScript = [];
@@ -366,12 +368,14 @@ function remove (name, options, cb) {
 			cb(error);
 		}
 	} else {
-		var systemdInUserMode = (options && options.userMode);
 		var initPath = "/etc/init.d/" + name;
-		var systemPath = "/usr/lib/systemd/system/" + name + ".service";
+
+		var systemdFolder = "/etc/systemd/system";
+		var systemdInUserMode = (options && options.userMode);
 		if (systemdInUserMode) {
-			systemPath = os.homedir() + "/.config/systemd/user/"+ name + ".service";
+			systemdFolder = os.homedir() + "/.config/systemd/user";
 		}
+		var systemPath = systemdFolder + "/" + name + ".service";
 
 		function removeCtlPaths() {
 			fs.unlink(initPath, function(error) {
@@ -393,7 +397,7 @@ function remove (name, options, cb) {
 			});
 		};
 
-		fs.stat("/usr/lib/systemd/system1", function(error, stats) {
+		fs.stat(systemdFolder, function(error, stats) {
 			if (error) {
 				if (error.code == "ENOENT") {
 					runProcess("chkconfig", ["--del", name], function(error) {

--- a/index.js
+++ b/index.js
@@ -4,8 +4,18 @@ var fs = require("fs");
 var os = require("os");
 var util = require ("util");
 
+var systemdFolder = "/etc/systemd/system";
+var systemdUserFolder = os.homedir() + "/.config/systemd/user";
+var initdFolder = "/etc/init.d";
+
 var serviceWrap;
 var runInitialised = false;
+var InstallTypes = Object.freeze({
+	"WINDOWS": "WINDOWS", 
+	"SYSTEMD_USER": "SYSTEMD_USER", 
+	"SYSTEMD_SYSTEM": "SYSTEMD_SYSTEM",
+	"INITD": "INITD"
+});
 
 var linuxStartStopScript = [
 	'#!/bin/bash',
@@ -161,6 +171,42 @@ function getServiceWrap () {
 	return serviceWrap;
 }
 
+function getInstallationType(name, cb) {
+	if (os.platform() == "win32") {
+		cb(null, InstallTypes.WINDOWS);
+	} else {
+		var userPath = systemdUserFolder;
+		if (name) {
+			userPath = userPath + "/" + name + ".service";
+		}
+		fs.stat(userPath, function (error, stats) {
+			if (error) {
+				if (error.code == "ENOENT") {
+					var systemPath = systemdFolder;
+					if (name) {
+						systemPath = systemPath + "/" + name + ".service";
+					}
+					fs.stat(systemPath, function (error, stats) {
+						if (error) {
+							if (error.code == "ENOENT") {
+								cb(null, InstallTypes.INITD);
+							} else {
+								cb(error);
+							}
+						} else {
+							cb(null, InstallTypes.SYSTEMD_SYSTEM);
+						}
+					});
+				} else {
+					cb(error);
+				}
+			} else {
+				cb(null, InstallTypes.SYSTEMD_USER);
+			}
+		});
+	}
+}
+
 function runProcess(path, args, cb) {
 	var child = child_process.spawn(path, args);
 
@@ -200,76 +246,117 @@ function add (name, options, cb) {
 	var username = options ? (options.username || null) : null;
 	var password = options ? (options.password || null) : null;
 
-	if (os.platform() == "win32") {
-		var displayName = (options && options.displayName)
-				? options.displayName
-				: name;
-		
-		var serviceArgs = [];
+	var nodeArgs = [];
+	if (options && options.nodeArgs)
+		for (var i = 0; i < options.nodeArgs.length; i++)
+			nodeArgs.push ("\"" + options.nodeArgs[i] + "\"");
 
-		serviceArgs.push (nodePath);
+	var programArgs = [];
+	if (options && options.programArgs)
+		for (var i = 0; i < options.programArgs.length; i++)
+			programArgs.push ("\"" + options.programArgs[i] + "\"");
 
-		if (options && options.nodeArgs)
-			for (var i = 0; i < options.nodeArgs.length; i++)
-				serviceArgs.push (options.nodeArgs[i]);
+	var nodeArgsStr = nodeArgs.join(" ");
+	var programArgsStr = programArgs.join(" ");
 
-		serviceArgs.push (programPath);
-	
-		if (options && options.programArgs)
-			for (var i = 0; i < options.programArgs.length; i++)
-				serviceArgs.push (options.programArgs[i]);
-	
-		for (var i = 0; i < serviceArgs.length; i++)
-			serviceArgs[i] = "\"" + serviceArgs[i] + "\"";
-	
-		var servicePath = serviceArgs.join (" ");
+	var ctlOptions = {
+		mode: 493 // rwxr-xr-x
+	};
 
-		try {
-			getServiceWrap ().add (name, displayName, servicePath, username,
-					password);
-			cb();
-		} catch (error) {
+	getInstallationType(null, function (error, type) {
+		if (error) {
 			cb(error);
-		}
-	} else {
-		var nodeArgs = [];
-		if (options && options.nodeArgs)
-			for (var i = 0; i < options.nodeArgs.length; i++)
-				nodeArgs.push ("\"" + options.nodeArgs[i] + "\"");
-
-		var programArgs = [];
-		if (options && options.programArgs)
-			for (var i = 0; i < options.programArgs.length; i++)
-				programArgs.push ("\"" + options.programArgs[i] + "\"");
+		} else {
+			switch (type) {
+				case InstallTypes.WINDOWS: {
+					var displayName = (options && options.displayName) ? options.displayName : name;
 		
-		var runLevels = [2, 3, 4, 5];
-		if (options && options.runLevels)
-			runLevels = options.runLevels;
+					var serviceArgs = [];
 
-		var nodeArgsStr = nodeArgs.join(" ");
-		var programArgsStr = programArgs.join(" ");
+					serviceArgs.push (nodePath);
 
-		var systemdTarget = "multi-user.target";
-		if (options && options.systemdTarget)
-			systemdTarget = options.systemdTarget;
+					if (options && options.nodeArgs)
+						for (var i = 0; i < options.nodeArgs.length; i++)
+							serviceArgs.push (options.nodeArgs[i]);
 
-		var initPath = "/etc/init.d/" + name;
-		var systemdFolder = "/etc/systemd/system";
-		
-		var systemdInUserMode = (options && options.userMode);
-		if (systemdInUserMode) {
-			systemdFolder = os.homedir() + "/.config/systemd/user";
-		}
+					serviceArgs.push (programPath);
+				
+					if (options && options.programArgs)
+						for (var i = 0; i < options.programArgs.length; i++)
+							serviceArgs.push (options.programArgs[i]);
+				
+					for (var i = 0; i < serviceArgs.length; i++)
+						serviceArgs[i] = "\"" + serviceArgs[i] + "\"";
+				
+					var servicePath = serviceArgs.join (" ");
 
-		var systemPath = systemdFolder + "/" + name + ".service";
+					try {
+						getServiceWrap ().add (name, displayName, servicePath, username,
+								password);
+						cb();
+					} catch (error) {
+						cb(error);
+					}
+					break;
+				}
+				case InstallTypes.SYSTEMD_USER:
+				case InstallTypes.SYSTEMD_SYSTEM: {
+					var systemdInstallPath;
+					if (options && options.userMode) {
+						systemdInstallPath = systemdUserFolder + "/" + name + ".service";
+						if (type != InstallTypes.SYSTEMD_USER) {
+							cb(new Error("User mode enabled, but "+systemdUserFolder+" doesn't exist"));
+							break;
+						}
+					} else {
+						systemdInstallPath = systemdFolder + "/" + name + ".service";
+					}
 
-		var ctlOptions = {
-			mode: 493 // rwxr-xr-x
-		};
+					var systemdTarget = "multi-user.target";
+					if (options && options.systemdTarget)
+						systemdTarget = options.systemdTarget;
 
-		fs.stat(systemdFolder, function(error, stats) {
-			if (error) {
-				if (error.code == "ENOENT") {
+					var systemUnit = [];
+
+					for (var i = 0; i < linuxSystemUnit.length; i++) {
+						var line = linuxSystemUnit[i];
+						
+						line = line.replace("##NAME##", name);
+						line = line.replace("##NODE_PATH##", nodePath);
+						line = line.replace("##NODE_ARGS##", nodeArgsStr);
+						line = line.replace("##PROGRAM_PATH##", programPath);
+						line = line.replace("##PROGRAM_ARGS##", programArgsStr);
+						line = line.replace("##TARGET##", systemdTarget);
+						
+						systemUnit.push(line);
+					}
+					var systemUnitStr = systemUnit.join("\n");
+
+					fs.writeFile(systemdInstallPath, systemUnitStr, ctlOptions, function(error) {
+						if (error) {
+							cb(new Error("writeFile(" + systemdInstallPath + ") failed: " + error.message));
+						} else {
+							var systemctlOpts = ["enable", name];
+							if (options && options.userMode) {
+								systemctlOpts.splice(0, 0, "--user");
+							}
+							runProcess("systemctl", systemctlOpts, function(error) {
+								if (error) {
+									cb(new Error("systemctl failed: " + error.message));
+								} else {
+									cb()
+								}
+							})
+						}
+					})
+					break;
+				}
+				case InstallTypes.INITD: {
+					var runLevels = [2, 3, 4, 5];
+					if (options && options.runLevels)
+						runLevels = options.runLevels;
+					var initPath = initdFolder + "/" + name;
+
 					var startStopScript = [];
 
 					for (var i = 0; i < linuxStartStopScript.length; i++) {
@@ -310,49 +397,15 @@ function add (name, options, cb) {
 								}
 							})
 						}
-					})
-				} else {
-					cb(new Error("stat(/usr/lib/systemd/system) failed: " + error.message));
+					});
+					break;
 				}
-			} else {
-				var systemUnit = [];
-
-				for (var i = 0; i < linuxSystemUnit.length; i++) {
-					var line = linuxSystemUnit[i];
-					
-					line = line.replace("##NAME##", name);
-					line = line.replace("##NODE_PATH##", nodePath);
-					line = line.replace("##NODE_ARGS##", nodeArgsStr);
-					line = line.replace("##PROGRAM_PATH##", programPath);
-					line = line.replace("##PROGRAM_ARGS##", programArgsStr);
-					line = line.replace("##TARGET##", systemdTarget);
-					
-					systemUnit.push(line);
+				default: {
+					cb(new Error("Unknown installation type: "+ type));
 				}
-				
-				var systemUnitStr = systemUnit.join("\n");
-
-				fs.writeFile(systemPath, systemUnitStr, ctlOptions, function(error) {
-					if (error) {
-						cb(new Error("writeFile(" + systemPath + ") failed: " + error.message));
-					} else {
-						var systemctlOpts = ["enable", name];
-						if (systemdInUserMode) {
-							systemctlOpts.splice(0, 0, "--user");
-						}
-						runProcess("systemctl", systemctlOpts, function(error) {
-							if (error) {
-								cb(new Error("systemctl failed: " + error.message));
-							} else {
-								cb()
-							}
-						})
-					}
-				})
 			}
-		})
-	}
-	
+		}
+	});
 	return this;
 }
 
@@ -360,51 +413,40 @@ function isStopRequested () {
 	return getServiceWrap ().isStopRequested ();
 }
 
-function remove (name, options, cb) {
-	if (! cb) {
-		cb = arguments[1];
-		options = {};
-	}
-	if (os.platform() == "win32") {
-		try {
-			getServiceWrap ().remove (name);
-			cb();
-		} catch (error) {
+function remove (name, cb) {
+	getInstallationType(name, function (error, type) {
+		if (error) {
 			cb(error);
-		}
-	} else {
-		var initPath = "/etc/init.d/" + name;
+		} else {
+			var systemctlOptions = ["disable", name];
+			var systemdInstallPath = systemdFolder + "/" + name + ".service";
 
-		var systemdFolder = "/etc/systemd/system";
-		var systemdInUserMode = (options && options.userMode);
-		if (systemdInUserMode) {
-			systemdFolder = os.homedir() + "/.config/systemd/user";
-		}
-		var systemPath = systemdFolder + "/" + name + ".service";
-
-		function removeCtlPaths() {
-			fs.unlink(initPath, function(error) {
-				if (error) {
-					if (error.code == "ENOENT") {
-						fs.unlink(systemPath, function(error) {
-							if (error) {
-								cb(new Error("unlink(" + systemPath + ") failed: " + error.message))
-							} else {
-								cb()
-							}
-						});
-					} else {
-						cb(new Error("unlink(" + initPath + ") failed: " + error.message))
+			switch (type) {
+				case InstallTypes.WINDOWS: {
+					try {
+						getServiceWrap().remove (name);
+						cb();
+					} catch (error) {
+						cb(error);
 					}
-				} else {
-					cb()
+					break;
 				}
-			});
-		};
-
-		fs.stat(systemdFolder, function(error, stats) {
-			if (error) {
-				if (error.code == "ENOENT") {
+				case InstallTypes.SYSTEMD_USER: {
+					systemctlOptions.splice(0, 0, "--user");
+					systemdInstallPath = systemdUserFolder + "/" + name + ".service";
+				}
+				case InstallTypes.SYSTEMD_SYSTEM: {
+					runProcess("systemctl", systemctlOptions, function(error) {
+						if (error) {
+							cb(new Error("systemctl failed: " + error.message));
+						} else {
+							fs.unlink(systemdInstallPath, cb);
+						}
+					});
+					break;
+				}
+				case InstallTypes.INITD: {
+					var initPath = initdFolder+ "/" + name;
 					runProcess("chkconfig", ["--del", name], function(error) {
 						if (error) {
 							if (error.code == "ENOENT") {
@@ -412,34 +454,25 @@ function remove (name, options, cb) {
 									if (error) {
 										cb(new Error("update-rc.d failed: " + error.message));
 									} else {
-										removeCtlPaths()
+										fs.unlink(initPath, cb);
 									}
 								});
 							} else {
 								cb(new Error("chkconfig failed: " + error.message));
 							}
 						} else {
-							removeCtlPaths()
+							fs.unlink(initPath, cb);
 						}
-					})
-				} else {
-					cb(new Error("stat(/usr/lib/systemd/system) failed: " + error.message));
+					});
+					break;
 				}
-			} else {
-				var systemctlOpts = ["disable", name];
-				if (systemdInUserMode) {
-					systemctlOpts.splice(0, 0, "--user");
+				default: {
+					cb(new Error("Unknown install type "+type));
 				}
-				runProcess("systemctl", systemctlOpts, function(error) {
-					if (error) {
-						cb(new Error("systemctl failed: " + error.message));
-					} else {
-						removeCtlPaths()
-					}
-				})
 			}
-		})
-	}
+		}
+	});
+	return this;
 }
 
 function run (stdoutLogStream, stderrLogStream, stopCallback) {
@@ -479,6 +512,7 @@ function run (stdoutLogStream, stderrLogStream, stopCallback) {
 	if (os.platform() == "win32") {
 		getServiceWrap ().run ();
 	}
+	return this;
 }
 
 function stop (rcode) {
@@ -488,7 +522,45 @@ function stop (rcode) {
 	process.exit (rcode || 0);
 }
 
+function restart(name, cb) {
+	getInstallationType(name, function (error, type) {
+		if (error) {
+			cb(error);
+		} else {
+			switch (type) {
+				case InstallTypes.WINDOWS: {
+					runProcess("net", ["stop", name], function (error) {
+						if (error) {
+							cb(error);
+						} else {
+							runProcess("net", ["start", name], cb);
+						}
+					});
+					break;
+				}
+				case InstallTypes.SYSTEMD_USER: {
+					runProcess("systemctl", ["--user", "restart", name], cb);
+					break;
+				}
+				case InstallTypes.SYSTEMD_SYSTEM: {
+					runProcess("systemctl", ["restart", name], cb);
+					break;
+				}
+				case InstallTypes.INITD: {
+					runProcess("bash", [initdFolder+"/"+name, "restart"], cb);
+					break;
+				}
+				default: {
+					cb(new Error("Unknown install type: "+ type));
+				}
+			}
+		}
+	});
+	return this;
+}
+
 exports.add = add;
 exports.remove = remove;
 exports.run = run;
 exports.stop = stop;
+exports.restart = restart;


### PR DESCRIPTION
Hi.

I added 2 new features:
1. systemd user mode support. Can be enabled by "userMode: true" option on add. It will install service script to user systemd folder in home directory.
2. restart action. Can be used for the restart of the installed service. System independent.

Also added WantedBy for systemd [Install] section. For service autostart.