### PR TITLE
Override the stdout/stderr handles instead of using the deprecated `__defineGetter__()` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -426,13 +426,8 @@ function run (stdoutLogStream, stderrLogStream, stopCallback) {
 	}
 
 	if (! runInitialised) {
-		process.__defineGetter__('stdout', function() {
-			return stdoutLogStream;
-		});
-		
-		process.__defineGetter__('stderr', function() {
-			return stderrLogStream;
-		});
+		process.stdout.write = stdoutLogStream.write.bind(stdoutLogStream);
+		process.stderr.write = stderrLogStream.write.bind(stderrLogStream);
 		
 		if (os.platform() == "win32") {
 			setInterval (function () {


### PR DESCRIPTION
hooks stdout/stderr's write methods instead of using `__defineGetter__`

[`__defineGetter__` seems to be deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__), and fails on my project (logs are empty).

this fix works for me but i've only tested it on my environment : node v8.4.0 on windows