### PR TITLE
Fixed an issue with how the stdout and stderr process properties are defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,8 +437,18 @@ function run (stdoutLogStream, stderrLogStream, stopCallback) {
 	}
 
 	if (! runInitialised) {
-		process.stdout.write = stdoutLogStream.write.bind(stdoutLogStream);
-		process.stderr.write = stderrLogStream.write.bind(stderrLogStream);
+		
+		Object.defineProperty(process, 'stdout', {
+			configurable: true,
+			enumerable: true,
+			get: () => stdoutLogStream
+		});
+
+		Object.defineProperty(process, 'stderr', {
+			configurable: true,
+			enumerable: true,
+			get: () => stderrLogStream
+		});
 		
 		if (os.platform() == "win32") {
 			setInterval (function () {


### PR DESCRIPTION
This is to fix the issue reported on https://github.com/stephenwvickers/node-os-service/issues/35.

I found this change to node which led me to try this: https://github.com/nodejs/node/pull/6766/files