### PR TITLE
Fixes nospaceships#43

### DIFF
--- a/index.js
+++ b/index.js
@@ -410,7 +410,7 @@ function remove (name, cb) {
 						else
 							removeCtlPaths(paths.splice(1));
 					} else {
-						cb(new Error("unlink(" + initPath + ") failed: " + error.message))
+						cb(new Error("unlink(" + paths[0] + ") failed: " + error.message))
 					}
 				} else {
 					cb()


### PR DESCRIPTION
leaves CentOS behaving as before while adding support for systemd based Debian systems that don't
have the /usr/lib/systemd/system folder
Looks for systemd at /usr/lib/systemd/system, then /etc/systemd/system, and finally /lib/systemd/system