### PR TITLE
update nan to latest version for compilation against node v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "nan": "2.10.x"
+    "nan": "^2.13.2"
   },
   "contributors": [
     {

--- a/src/service.cc
+++ b/src/service.cc
@@ -111,27 +111,18 @@ DWORD __stdcall run_thread (LPVOID param) {
 
 namespace service {
 
-void InitAll (Handle<Object> exports) {
+void InitAll (v8::Local<v8::Object> exports) {
 	pthread_mutex_init(&status_handle_mtx, NULL);
 	pthread_mutex_init(&stop_requested_mtx, NULL);
 	pthread_mutex_init(&stop_service_mtx, NULL);
 	
 	pthread_cond_init(&stop_service, NULL);
 
-	exports->Set(Nan::New("add").ToLocalChecked(),
-			Nan::GetFunction(Nan::New<FunctionTemplate>(Add)).ToLocalChecked());
-
-	exports->Set(Nan::New("isStopRequested").ToLocalChecked(),
-			Nan::GetFunction(Nan::New<FunctionTemplate>(IsStopRequested)).ToLocalChecked());
-	
-	exports->Set(Nan::New("remove").ToLocalChecked(),
-			Nan::GetFunction(Nan::New<FunctionTemplate>(Remove)).ToLocalChecked());
-	
-	exports->Set(Nan::New("run").ToLocalChecked(),
-			Nan::GetFunction(Nan::New<FunctionTemplate>(Run)).ToLocalChecked());
-	
-	exports->Set(Nan::New("stop").ToLocalChecked(),
-			Nan::GetFunction(Nan::New<FunctionTemplate>(Stop)).ToLocalChecked());
+	Nan::SetMethod(exports, "add", Add);
+	Nan::SetMethod(exports, "isStopRequested", IsStopRequested);
+	Nan::SetMethod(exports, "remove", Remove);
+	Nan::SetMethod(exports, "run", Run);
+	Nan::SetMethod(exports, "stop", Stop);
 }
 
 NODE_MODULE(service, InitAll)

--- a/src/service.h
+++ b/src/service.h
@@ -23,7 +23,7 @@ using namespace v8;
 
 namespace service {
 
-static void Init(Handle<Object> exports);
+static void InitAll(v8::Local<v8::Object> exports);
 
 static NAN_METHOD(Add);
 static NAN_METHOD(IsStopRequested);


### PR DESCRIPTION
compiling against Node v12 requires a newer version of nan. However, it seems the signatures for adding methods changed (in particular "Handle" was causing compilation errors), so I updated the exports type, and changed "Set" to "SetMethod" to avoid deprecation warnings.

TBH I've only tested against the included example script, but all commands worked fine.