### PR TITLE
const_cast to avoid compiler error

### DIFF
--- a/src/service.cc
+++ b/src/service.cc
@@ -87,7 +87,7 @@ VOID WINAPI run (DWORD argc, LPTSTR *argv) {
 }
 
 DWORD __stdcall run_thread (LPVOID param) {
-	SERVICE_TABLE_ENTRY table[] = {{"", run}, {0, }};
+	SERVICE_TABLE_ENTRY table[] = {{const_cast<LPSTR>(""), run}, {0, }};
 
 	if (StartServiceCtrlDispatcher (table)) {
 		while (1) {


### PR DESCRIPTION
error C2440: 'initializing': cannot convert from 'const char [1]' to 'LPSTR'